### PR TITLE
Adds test case for multiple potion blueprints

### DIFF
--- a/flask_potion/__init__.py
+++ b/flask_potion/__init__.py
@@ -55,6 +55,7 @@ class Api(object):
     """
     def __init__(self, app=None, decorators=None, prefix=None, title=None, description=None, default_manager=None):
         self.app = app
+        self.blueprint = None
         self.prefix = prefix or ''
         self.decorators = decorators or []
         self.title = title
@@ -77,6 +78,19 @@ class Api(object):
             self.init_app(app)
 
     def init_app(self, app):
+        # If app is a blueprint, defer the initialization
+        try:
+            app.record(self._deferred_blueprint_init)
+        # Flask.Blueprint has a 'record' attribute, Flask.Api does not
+        except AttributeError:
+            self._init_app(app)
+        else:
+            self.blueprint = app
+
+    def _deferred_blueprint_init(self, setup_state):
+        self._init_app(setup_state.app)
+
+    def _init_app(self, app):
         """
         :param app: a :class:`Flask` instance
         """
@@ -142,7 +156,10 @@ class Api(object):
         return OrderedDict(schema), 200, {'Content-Type': 'application/schema+json'}
 
     def add_route(self, route, resource, endpoint=None, decorator=None):
-        endpoint = endpoint or '.'.join((resource.meta.name, route.relation))
+        if self.blueprint is None:
+            endpoint = endpoint or '.'.join((resource.meta.name, route.relation))
+        else:
+            endpoint = endpoint or '_'.join((resource.meta.name, route.relation))
         methods = [route.method]
         rule = route.rule_factory(resource)
 

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -1,0 +1,23 @@
+from flask import Blueprint
+from flask_potion import Api
+from flask_potion.contrib.memory.manager import MemoryManager
+from flask_potion.resource import ModelResource
+from tests import BaseTestCase
+
+
+class BlueprintApiTestCase(BaseTestCase):
+    def test_api_blueprint(self):
+        class SampleResource(ModelResource):
+            class Meta:
+                name = "samples"
+                model = "samples"
+                manager = MemoryManager
+
+        api_bp = Blueprint("potion_blueprint", __name__.split(".")[0])
+        api = Api(api_bp)
+        api.add_resource(SampleResource)
+
+        # Register Blueprint
+        self.app.register_blueprint(api_bp)
+        response = self.client.get("/samples")
+        self.assert200(response)

--- a/tests/test_api_blueprint.py
+++ b/tests/test_api_blueprint.py
@@ -6,8 +6,10 @@ from tests import BaseTestCase
 
 
 class BlueprintApiTestCase(BaseTestCase):
+
     def test_api_blueprint(self):
         class SampleResource(ModelResource):
+
             class Meta:
                 name = "samples"
                 model = "samples"
@@ -20,4 +22,37 @@ class BlueprintApiTestCase(BaseTestCase):
         # Register Blueprint
         self.app.register_blueprint(api_bp)
         response = self.client.get("/samples")
+        self.assert200(response)
+
+    def test_multiple_api_blueprints(self):
+        class SampleResource(ModelResource):
+
+            class Meta:
+                name = "samples"
+                model = "samples"
+                manager = MemoryManager
+
+        class SampleResource2(ModelResource):
+
+            class Meta:
+                name = "samples2"
+                model = "samples"
+                manager = MemoryManager
+
+        api_bp = Blueprint("potion_blueprint", __name__.split(".")[0])
+        api = Api(api_bp)
+        api.add_resource(SampleResource)
+
+        api_bp2 = Blueprint("potion_blueprint2", __name__.split(".")[0])
+        api2 = Api(api_bp2)
+        api2.add_resource(SampleResource2)
+
+        # Register Blueprint
+        self.app.register_blueprint(api_bp)
+        self.app.register_blueprint(api_bp2)
+
+        response = self.client.get("/samples")
+        self.assert200(response)
+
+        response = self.client.get("/samples2")
         self.assert200(response)


### PR DESCRIPTION
I feel that one of the main benefits of adding blueprint support would be the ability to register multiple api blueprints on a single flask app.

In the current implementation when you try to register more than one Api instance on an app it will throw the error:
```
  File "/some/dir/lib/python2.7/site-packages/flask/app.py", line 984, in add_url_rule
    'existing endpoint function: %s' % endpoint)
AssertionError: View function mapping is overwriting an existing endpoint function: schema
```

This is because on registration each api blueprint will try to create a generic ```/schema``` endpoint that describes the available resources, causing a conflict unless a prefix is used.


There are a few different ways this could be solved, and I think it'd be worth a discussion.

Here is test case demonstrating the expected behavior, failing as described above.